### PR TITLE
Add row and column labels to the game board

### DIFF
--- a/client/content/banqi.css
+++ b/client/content/banqi.css
@@ -39,7 +39,7 @@ td.banqi-square {
   background-color: white;
 }
 
-.header {
+table.banqi-board th {
   color: darkslategrey;
   text-align: center;
   font-size: 2em;

--- a/client/content/banqi.css
+++ b/client/content/banqi.css
@@ -1,7 +1,6 @@
 table.banqi-board{
   /*border-collapse:collapse;*/
   border-spacing:0;
-  border:1px black solid;
 }
 .chat{
   display:inline-block;
@@ -38,6 +37,13 @@ td.banqi-square {
   background-repeat: no-repeat;
   background-position:center center;
   background-color: white;
+}
+
+td.header {
+  color: darkslategrey;
+  text-align: center;
+  font-size: 2em;
+  vertical-align: middle;
 }
 
 td.banqi-square.selected{

--- a/client/content/banqi.css
+++ b/client/content/banqi.css
@@ -39,7 +39,7 @@ td.banqi-square {
   background-color: white;
 }
 
-td.header {
+.header {
   color: darkslategrey;
   text-align: center;
   font-size: 2em;

--- a/client/jsx/Board.jsx
+++ b/client/jsx/Board.jsx
@@ -32,21 +32,19 @@ var Square = React.createClass({
 
 var RowHeader = React.createClass({
   render: function() {
-    var classString = "header row-header";
     var rank = this.props.rank;
     return(
-    <td className={classString}>
+    <th scope="row">
       {"1234"[rank]}
-    </td>);
+    </th>);
   },
 });
 
 var ColumnHeader = React.createClass({
   render: function() {
-    var classString = "header column-header";
     var file = this.props.file;
     return(
-    <th className={classString}>
+    <th scope="col">
       {"ABCDEFGH"[file]}
     </th>);
   },

--- a/client/jsx/Board.jsx
+++ b/client/jsx/Board.jsx
@@ -30,6 +30,28 @@ var Square = React.createClass({
   },
 });
 
+var RowHeader = React.createClass({
+  render: function() {
+    var classString = "header row-header";
+    var rank = this.props.rank;
+    return(
+    <td className={classString}>
+      {"1234"[rank]}
+    </td>);
+  },
+});
+
+var ColumnHeader = React.createClass({
+  render: function() {
+    var classString = "header column-header";
+    var file = this.props.file;
+    return(
+    <td className={classString}>
+      {"ABCDEFGH"[file]}
+    </td>);
+  },
+});
+
 var Board = React.createClass({
   flipPiece: function(square){
     var files = 'ABCDEFGH';
@@ -69,7 +91,13 @@ var Board = React.createClass({
     var current = this.state.selected;
     var lastMove = this.props.lastMove
     var comp = this;
+    var colHeaders = []
+    colHeaders.push(<td />); // the row-label column needs no column header
+    for (var i=0; i < 8; i++) {
+      colHeaders.push(<ColumnHeader file={i} />)
+    }
     var rowElements = this.props.board.map(function(row, rank){
+      var rowHeader = <RowHeader rank={rank} />
       var squares = row.map(function(square, file){
         return (
           <Square
@@ -84,10 +112,11 @@ var Board = React.createClass({
           </Square>);
         }
       );
-      return (<tr>{squares}</tr>);
+      return (<tr>{rowHeader}{squares}</tr>);
     });
     return (
       <table className="banqi-board">
+        {colHeaders}
         {rowElements}
       </table>
     )

--- a/client/jsx/Board.jsx
+++ b/client/jsx/Board.jsx
@@ -46,9 +46,9 @@ var ColumnHeader = React.createClass({
     var classString = "header column-header";
     var file = this.props.file;
     return(
-    <td className={classString}>
+    <th className={classString}>
       {"ABCDEFGH"[file]}
-    </td>);
+    </th>);
   },
 });
 
@@ -92,7 +92,7 @@ var Board = React.createClass({
     var lastMove = this.props.lastMove
     var comp = this;
     var colHeaders = []
-    colHeaders.push(<td />); // the row-label column needs no column header
+    colHeaders.push(<th />); // the row-label column needs no column header
     for (var i=0; i < 8; i++) {
       colHeaders.push(<ColumnHeader file={i} />)
     }


### PR DESCRIPTION
I removed the table border (the CSS rule for `table.banqi-board`) because drawing a box around the board-and-labels looks wrong. That border probably wasn't necessary anyway, because each square is already bordered.

Fixes #30 "Label rows and columns".