### PR TITLE
Change database to sqlite3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,4 @@ _testmain.go
 
 *.exe
 
-Caddyfile
-conf/paoSettings.json
+conf/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 
 conf/*.json
+*.s3db

--- a/conf/paoSettings.json.sample
+++ b/conf/paoSettings.json.sample
@@ -1,7 +1,7 @@
 {
   "DbConfig" : {
-    "driver" : "postgres",
-    "connectionString" : "user=myUser password=myPassword sslmode=disable dbname=myDb"
+    "driver" : "sqlite3",
+    "connectionString" : "pao.s3db"
   },
   "AuthConfig" : {
     "encryptionKey" : "foo-bar-baz-blat"

--- a/pao.go
+++ b/pao.go
@@ -11,7 +11,7 @@ import (
 	paoDb "github.com/arbrown/pao/db"
 	"github.com/arbrown/pao/game"
 	"github.com/arbrown/pao/settings"
-	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 var (
@@ -28,11 +28,6 @@ func main() {
 	} else {
 		fmt.Printf("Settings: %+v\n", s)
 	}
-	a, err = paoDb.NewAuth(s)
-	if err != nil {
-		fmt.Println("Could not create auth")
-		fmt.Println(err.Error())
-	}
 	// create db connection
 	db, err := sql.Open(s.DbConfig.Driver, s.DbConfig.ConnectionString)
 	if err != nil {
@@ -41,6 +36,12 @@ func main() {
 	} else {
 		paoDb.Init(db)
 	}
+	a, err = paoDb.NewAuth(s)
+	if err != nil {
+		fmt.Println("Could not create auth")
+		fmt.Println(err.Error())
+	}
+
 
 	httpMux := http.NewServeMux()
 	httpMux.Handle("/listGames", listGamesHandler{games: games})


### PR DESCRIPTION
Sqlite3 should lower the barrier to local development and will be fine for production use.  Note that there is a one-time compilation required (using gcc) since sqlite3 is a c library.

https://github.com/mattn/go-sqlite3#installation