### PR TITLE
Enhanced boneyard

### DIFF
--- a/client/content/banqi.css
+++ b/client/content/banqi.css
@@ -105,13 +105,21 @@ html:before {
 .dead-pieces {
   height: auto;
 }
-.dead-pieces .banqi-square{
+.dead-pieces .banqi-square {
   height:45px;
   width:45px;
   background-repeat:no-repeat;
   background-size:cover;
   margin:2px;
   display:inline-block;
+}
+.dead-pieces .banqi-square.alive {
+    opacity: 50%;
+}
+.dead-pieces .banqi-square.unborn {
+    opacity: 30%;
+    -webkit-filter: grayscale(100%);
+    filter: grayscale(100%);
 }
 
 .lobby-game .banqi-square {

--- a/client/content/banqi.css
+++ b/client/content/banqi.css
@@ -113,12 +113,24 @@ html:before {
   margin:2px;
   display:inline-block;
 }
-.dead-pieces .banqi-square.live {
-    opacity: 20%;
+.dead-pieces .banqi-square.dead::before {
+    content: "";
+    background-color: black;
+    opacity: 40%;
+    border-radius: ;
+    width:inherit;
+    height:inherit;
+    position: fixed;
 }
-.dead-pieces .banqi-square.unborn {
-  opacity: 20%;
-  background-image: url("/images/unflipped-piece.svg");
+
+.dead-pieces .banqi-square.unborn::before {
+    content: "";
+    background-color: green;
+    opacity: 40%;
+    border-radius: 50%;
+    width:inherit;
+    height:inherit;
+    position: fixed;
 }
 
 .lobby-game .banqi-square {

--- a/client/content/banqi.css
+++ b/client/content/banqi.css
@@ -113,13 +113,12 @@ html:before {
   margin:2px;
   display:inline-block;
 }
-.dead-pieces .banqi-square.alive {
-    opacity: 50%;
+.dead-pieces .banqi-square.live {
+    opacity: 20%;
 }
 .dead-pieces .banqi-square.unborn {
-    opacity: 30%;
-    -webkit-filter: grayscale(100%);
-    filter: grayscale(100%);
+  opacity: 20%;
+  background-image: url("/images/unflipped-piece.svg");
 }
 
 .lobby-game .banqi-square {

--- a/client/content/banqi.css
+++ b/client/content/banqi.css
@@ -117,7 +117,7 @@ html:before {
     content: "";
     background-color: black;
     opacity: 40%;
-    border-radius: ;
+    border-radius: 50%;
     width:inherit;
     height:inherit;
     position: fixed;

--- a/client/jsx/Dead.jsx
+++ b/client/jsx/Dead.jsx
@@ -15,8 +15,9 @@ var DeadPieces = React.createClass({
       redDead.sort(StrengthCompareD);
       blackDead.sort(StrengthCompareD);
     }
-    var redPieces = redDead.map(this.pieceMap);
-    var blackPieces = blackDead.map(this.pieceMap);
+    var livePieces = this.collectKnownPieces(this.props.board)
+    var redPieces = this.deadPieces("kggeecchhpppppqq", redDead, livePieces);
+    var blackPieces = this.deadPieces("KGGEECCHHPPPPPQQ", blackDead, livePieces);
     return (
       <div className="dead-pieces">
         <div className="red-dead">{redPieces}</div>
@@ -30,21 +31,55 @@ var DeadPieces = React.createClass({
       lastDead: ""
     };
   },
-  pieceMap: function(piece){
+  deadPiece: function(piece, state, lastMove) {
+    // `state` is 'dead', 'alive', or 'unborn'
     var classes = []
     classes.push('banqi-square');
-    classes.push('dead');
-    if (this.props.lastDead == piece){
+    classes.push(state);
+    if (lastMove) {
         classes.push('last-move');
-        this.props.lastDead = ''; // Yuck
     }
     classes.push(NotationToCss[piece]);
     var classString = classes.reduce(function(p, c) { return p + " " + c});
     return <div className={classString} />
+  },
+  deadPieces: function(all, dead, alive) {
+    var lastDead = this.props.lastDead;
+    var self = this;
+    dead = dead.reduce(function(p, c) { return p + " " + c}, '');
+    alive = alive.reduce(function(p, c) { return p + " " + c}, '');
+    return all.split('').map(function(piece) {
+      var state = 'unborn'
+      var lastMove = false;
+      if (dead.indexOf(piece) >= 0) {
+        state = 'dead';
+        dead = dead.replace(piece, '');
+        if (piece == lastDead) {
+          lastMove = true;
+          lastDead = ''
+        }
+      } else if (alive.indexOf(piece) >= 0) {
+        state = 'alive';
+        alive = alive.replace(piece, '')
+      }
+      return self.deadPiece(piece, state, lastMove);
+    })
+  },
+  collectKnownPieces: function(board) {
+    var knownPieces = [];
+    for (var rank=0; rank < 4; rank++) {
+      for (var file=0; file < 8; file++) {
+        var piece = board[rank][file]
+        if (piece != '?' && piece != '.') {
+          knownPieces.push(piece);
+        }
+      }
+    }
+    return knownPieces;
   }
 });
 
-PieceStrength = ["Q","P","H","C","E","G","K"]                
+PieceStrength = ["Q","P","H","C","E","G","K"]
 StrengthCompareD = function(a,b){
   return StrengthCompare(a,b,true)
 };

--- a/client/jsx/Dead.jsx
+++ b/client/jsx/Dead.jsx
@@ -32,22 +32,23 @@ var DeadPieces = React.createClass({
     };
   },
   deadPiece: function(piece, state, lastMove) {
-    // `state` is 'dead', 'alive', or 'unborn'
+    // `state` is 'dead', 'live', or 'unborn'
     var classes = []
     classes.push('banqi-square');
     classes.push(state);
     if (lastMove) {
         classes.push('last-move');
     }
+    var type = NotationToCss[piece];
     classes.push(NotationToCss[piece]);
     var classString = classes.reduce(function(p, c) { return p + " " + c});
-    return <div className={classString} />
+    return <div className={classString} title={state + " " + type} />
   },
-  deadPieces: function(all, dead, alive) {
+  deadPieces: function(all, dead, live) {
     var lastDead = this.props.lastDead;
     var self = this;
     dead = dead.reduce(function(p, c) { return p + " " + c}, '');
-    alive = alive.reduce(function(p, c) { return p + " " + c}, '');
+    live = live.reduce(function(p, c) { return p + " " + c}, '');
     return all.split('').map(function(piece) {
       var state = 'unborn'
       var lastMove = false;
@@ -58,9 +59,9 @@ var DeadPieces = React.createClass({
           lastMove = true;
           lastDead = ''
         }
-      } else if (alive.indexOf(piece) >= 0) {
-        state = 'alive';
-        alive = alive.replace(piece, '')
+      } else if (live.indexOf(piece) >= 0) {
+        state = 'live';
+        live = live.replace(piece, '')
       }
       return self.deadPiece(piece, state, lastMove);
     })

--- a/client/jsx/Game.jsx
+++ b/client/jsx/Game.jsx
@@ -8,14 +8,16 @@ var Game = React.createClass({
                   myColor={this.state.myColor}
                   whoseTurn={this.state.whoseTurn}
                   turnColor={this.state.turnColor}
-                  numPlayers={this.state.numPlayers}/>
+                  numPlayers={this.state.numPlayers} />
        <Board
           board={this.state.board}
           myTurn={this.state.myTurn}
           sendMove={this.sendMove}
           myColor={this.state.myColor}
           lastMove={this.state.lastMove} />
-        <DeadPieces dead={this.state.dead} lastDead={this.state.lastDead}  />
+       <DeadPieces dead={this.state.dead}
+         lastDead={this.state.lastDead}
+         board={this.state.board} />
       <Chat submitChat={this.submitChat} chats={this.state.chats} />
       <button className="goBackButton"><a href="/">Go back to lobby</a></button>
       <button className="resignButton" onClick={this.resign}>Resign</button>


### PR DESCRIPTION
All game pieces are represented in `div.dead-pieces`. 

- Dead pieces are rendered as before, except that they now have a mouse-over tool tip that reads, e.g., "dead red-horse". 
- Pieces that are currently in play (i.e., face up on the board) are rendered in the boneyard dimmed-out (opacity:20%) with a tooltip like "live black-canon". 
- Pieces that have not yet been turned up are rendered in the boneyard as a dimmed-out green disc with a tooltip like "unborn red-king".

I hadn't seen https://github.com/arbrown/pao/issues/38#issuecomment-632743229 until after I'd coded this up, so it's only similar to that picture. I'll try to CSS unborn pieces into that look, and report back.