### PR TITLE
Fix minor spacing pet peeve with username and "Sign Out"

### DIFF
--- a/client/jsx/Login.jsx
+++ b/client/jsx/Login.jsx
@@ -14,7 +14,7 @@ var Login = React.createClass({
     } else {
       return (
         <div className="login-div">
-          {this.state.user}
+          {this.state.user}<br />
           <a href="/logout">Sign Out</a>
         </div>
       )


### PR DESCRIPTION
Don't ram username and "Sign Out" together.