### PR TITLE
Game notation heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Then, another player can join your game and it will begin.
 ![join](./screenshots/join-existing.png)  
 Have fun!
 ![game](./screenshots/game2.png)  
+
 Banqi Game Notation
 ---------------------
 The game code uses a character-based notation to store and transmit piece information.


### PR DESCRIPTION
Although GitHub renders "Banqi Game Notation" in large bold text, it does not provide a link anchor for it. Adding a newline before the heading fixes that.